### PR TITLE
HTTP client: add an user agent

### DIFF
--- a/http.go
+++ b/http.go
@@ -2,6 +2,7 @@ package kroki
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -28,7 +29,10 @@ func (c *Client) GetRequestContext(ctx context.Context, payload string, diagramT
 	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, c.Config.Timeout)
 	defer cancel()
-	req.Header = http.Header{"Accept": {"text/plain"}}
+	req.Header = http.Header{
+		"Accept":     {"text/plain"},
+		"User-Agent": {fmt.Sprintf("kroki-go %s", Version)},
+	}
 	req = req.WithContext(timeoutCtx)
 
 	// execute the request

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package kroki
+
+// Version of kroki-go
+const Version = "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Fix #7 

tested with a netcat server:
```
Connection from localhost 37094 received!
GET /graphviz/png/eNpKyUwvSizIUHBXqOZSUPBIzcnJ17ULzy_KSeGqBQQAAP__hM0JGg== HTTP/1.1
Host: localhost:8000
User-Agent: kroki-go 0.3.0-SNAPSHOT
Accept: text/plain
Accept-Encoding: gzip
```