### PR TITLE
remove archived package, use std

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,8 @@
 package kroki
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // ImageFormat the image format returned by Kroki
@@ -140,7 +139,7 @@ func (configuration *Configuration) UnmarshalYAML(unmarshal func(interface{}) er
 	}
 
 	if err := unmarshal(&rawConfig); err != nil {
-		return errors.Wrap(err, "fail to decode the yaml configuration")
+		return fmt.Errorf("fail to decode the yaml configuration: %w", err)
 	}
 	*configuration = Configuration{
 		URL:     rawConfig.URL,

--- a/generate.go
+++ b/generate.go
@@ -1,9 +1,8 @@
 package kroki
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 const MAX_URI_LENGTH = 4096
@@ -25,7 +24,7 @@ func (c *Client) FromString(input string, diagramType DiagramType, imageFormat I
 func (c *Client) FromFile(path string, diagramType DiagramType, imageFormat ImageFormat) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return "", errors.Wrapf(err, "fail to read file '%s'", path)
+		return "", fmt.Errorf("fail to read file '%s': %w", path, err)
 	}
 	input := string(content)
 	payload, err := CreatePayload(input)
@@ -44,16 +43,16 @@ func (c *Client) FromFile(path string, diagramType DiagramType, imageFormat Imag
 func (c *Client) WriteToFile(path string, result string) error {
 	file, err := os.Create(path)
 	if err != nil {
-		return errors.Wrapf(err, "fail to create file '%s'", path)
+		return fmt.Errorf("fail to create file '%s': %w", path, err)
 	}
 	defer file.Close()
 	_, err = file.Write([]byte(result))
 	if err != nil {
-		return errors.Wrapf(err, "fail to write to file '%s'", path)
+		return fmt.Errorf("fail to write to file '%s': %w", path, err)
 	}
 	err = file.Sync()
 	if err != nil {
-		return errors.Wrapf(err, "fail to sync file '%s'", path)
+		return fmt.Errorf("fail to sync file '%s': %w", path, err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/yuzutech/kroki-go
 
 go 1.18
 
-require (
-	github.com/pkg/errors v0.9.1
-	gopkg.in/yaml.v3 v3.0.1
-)
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/http.go
+++ b/http.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 	"path"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // PostRequestContext executes a POST request on Kroki using a context
@@ -19,14 +17,14 @@ func (c *Client) PostRequestContext(ctx context.Context, payload string, diagram
 	// construct the url
 	u, err := url.Parse(c.Config.URL)
 	if err != nil {
-		return "", errors.Wrapf(err, "fail to create the URL from %s", c.Config.URL)
+		return "", (fmt.Errorf("fail to create the URL from %s: %w", c.Config.URL, err))
 	}
 	u.Path = path.Join(u.Path, string(diagramType), string(imageFormat))
 
 	// construct the request
 	req, err := http.NewRequest("POST", u.String(), strings.NewReader(payload))
 	if err != nil {
-		return "", errors.Wrap(err, "fail to create the request")
+		return "", fmt.Errorf("fail to create the request: %w", err)
 	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, c.Config.Timeout)
 	defer cancel()
@@ -40,7 +38,7 @@ func (c *Client) PostRequestContext(ctx context.Context, payload string, diagram
 	client := http.DefaultClient
 	response, err := client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "fail to generate the image")
+		return "", fmt.Errorf("fail to generate the image: %w", err)
 	}
 
 	// read the result
@@ -53,13 +51,13 @@ func (c *Client) PostRequestContext(ctx context.Context, payload string, diagram
 		} else {
 			message = string(body)
 		}
-		return "", errors.Errorf(
+		return "", fmt.Errorf(
 			"fail to generate the image {status: %d, body: %s}",
 			response.StatusCode, message)
 	}
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "fail to read the response body")
+		return "", fmt.Errorf("fail to read the response body: %w", err)
 	}
 	return string(body), nil
 }
@@ -77,14 +75,14 @@ func (c *Client) GetRequestContext(ctx context.Context, payload string, diagramT
 	// construct the url
 	u, err := url.Parse(c.Config.URL)
 	if err != nil {
-		return "", errors.Wrapf(err, "fail to create the URL from %s", c.Config.URL)
+		return "", fmt.Errorf("fail to create the URL from %s: %w", c.Config.URL, err)
 	}
 	u.Path = path.Join(u.Path, string(diagramType), string(imageFormat), payload)
 
 	// construct the request
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		return "", errors.Wrap(err, "fail to create the request")
+		return "", fmt.Errorf("fail to create the request: %w", err)
 	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, c.Config.Timeout)
 	defer cancel()
@@ -98,7 +96,7 @@ func (c *Client) GetRequestContext(ctx context.Context, payload string, diagramT
 	client := http.DefaultClient
 	response, err := client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "fail to generate the image")
+		return "", fmt.Errorf("fail to generate the image: %w", err)
 	}
 
 	// read the result
@@ -111,13 +109,13 @@ func (c *Client) GetRequestContext(ctx context.Context, payload string, diagramT
 		} else {
 			message = string(body)
 		}
-		return "", errors.Errorf(
+		return "", fmt.Errorf(
 			"fail to generate the image {status: %d, body: %s}",
 			response.StatusCode, message)
 	}
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "fail to read the response body")
+		return "", fmt.Errorf("fail to read the response body: %w", err)
 	}
 	return string(body), nil
 }

--- a/payload.go
+++ b/payload.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"encoding/base64"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // CreatePayload takes a string and returns a payload in deflate + base64 format
@@ -14,12 +13,12 @@ func CreatePayload(input string) (string, error) {
 	var buffer bytes.Buffer
 	writer, err := zlib.NewWriterLevel(&buffer, 9)
 	if err != nil {
-		return "", errors.Wrap(err, "fail to create the writer")
+		return "", fmt.Errorf("fail to create the writer: %w", err)
 	}
 	_, err = writer.Write([]byte(input))
 	writer.Close()
 	if err != nil {
-		return "", errors.Wrap(err, "fail to create the payload")
+		return "", fmt.Errorf("fail to create the payload: %w", err)
 	}
 	result := base64.URLEncoding.EncodeToString(buffer.Bytes())
 	return result, nil


### PR DESCRIPTION
- remove "github.com/pkg/errors", [it archived](https://github.com/pkg/errors).
- go [wrap errors enabled in Go 1.13](https://go.dev/blog/go1.13-errors)

## tests

https://go.dev/play/p/NG8szof-xAJ

```go
	err := fmt.Errorf("test-Wrap")
	fmt.Println(errors.Wrap(err, "fail to decode the yaml configuration"))
	fmt.Println(fmt.Errorf("fail to decode the yaml configuration: %w", err))

	path := "test-Wrapf"
	fmt.Println(errors.Wrapf(err, "fail to read file '%s'", path))
	fmt.Println(fmt.Errorf("fail to read file '%s': %w", path, err))

	message := "test-Errorf"
	fmt.Println(fmt.Errorf(
		"fail to generate the image {status: %d, body: %s}",
		500, message))
	fmt.Println(fmt.Errorf(
		"fail to generate the image {status: %d, body: %s}",
		500, message))
```

```
fail to decode the yaml configuration: test-Wrap
fail to decode the yaml configuration: test-Wrap
fail to read file 'test-Wrapf': test-Wrap
fail to read file 'test-Wrapf': test-Wrap
fail to generate the image {status: 500, body: test-Errorf}
fail to generate the image {status: 500, body: test-Errorf}
```